### PR TITLE
One way to fix the out of bound access issue.

### DIFF
--- a/include/scalar.hpp
+++ b/include/scalar.hpp
@@ -210,23 +210,15 @@ void rsh(std::array<uint64_t, N>& out, const std::array<uint64_t, N>& in, uint64
 
 } // namespace scalar
 
-void bn_divn_low(uint64_t *c, uint64_t *d, uint64_t *a, int sa, uint64_t *b, int sb);
+void bn_divn_low(uint64_t *c, uint64_t *d, const uint64_t *ina, int sa, const uint64_t *inb, int sb);
 
 template<size_t N>
 fp fp::modPrime(std::array<uint64_t, N> k)
 {
     std::array<uint64_t, N> quotient = {0};
     std::array<uint64_t, N> remainder = {0};
-    // be conservative with scratch memory (https://github.com/relic-toolkit/relic/blob/ddd1984a76aa9c96a12ebdf5c6786b0ee6a26ef8/src/bn/relic_bn_div.c#L79)
-    // with gcc std::array<uint64_t, 6> modulus = fp::MODULUS.d works fine but clang needs the extra words
-    std::array<uint64_t, N> modulus = {0};
-    modulus[0] = fp::MODULUS.d[0];
-    modulus[1] = fp::MODULUS.d[1];
-    modulus[2] = fp::MODULUS.d[2];
-    modulus[3] = fp::MODULUS.d[3];
-    modulus[4] = fp::MODULUS.d[4];
-    modulus[5] = fp::MODULUS.d[5];
-    bn_divn_low(quotient.data(), remainder.data(), k.data(), N, modulus.data(), 6);
+
+    bn_divn_low(quotient.data(), remainder.data(), k.data(), N, fp::MODULUS.d.data(), 6);
     std::array<uint64_t, 6> _r = {remainder[0], remainder[1], remainder[2], remainder[3], remainder[4], remainder[5]};
     return fp(_r).toMont();
 }

--- a/src/scalar.cpp
+++ b/src/scalar.cpp
@@ -241,11 +241,23 @@ void bn_divn_low(uint64_t *c, uint64_t *d, uint64_t *a, int sa, uint64_t *b, int
 	mpn_tdiv_qr(c, d, 0, a, sa, b, sb);
 }
 #else
-void bn_divn_low(uint64_t *c, uint64_t *d, uint64_t *a, int sa, uint64_t *b, int sb)
+void bn_divn_low(uint64_t *c, uint64_t *d, const uint64_t *ina, int sa, const uint64_t *inb, int sb)
 {
     int norm, i, n, t, sd;
     uint64_t carry, t1[3], t2[3];
-
+    assert(sa >= sb);
+    std::vector<uint64_t> va;
+    std::vector<uint64_t> vb;
+    // a might be expanded.
+    va.reserve(sa + 1);
+    // b[sa] might be acessed.
+    vb.reserve(sa + 1);
+    va.assign(ina, &ina[sa]);
+    vb.assign(inb, &inb[sb]);
+    va.resize(sa + 1, 0);
+    vb.resize(sa + 1, 0);
+    uint64_t *a = va.data();
+    uint64_t *b = vb.data();
     // Normalize x and y so that the leading digit of y is bigger than 2^(RLC_DIG-1).
     norm = (64 - __builtin_clzll(b[sb - 1])) % 64;
 

--- a/src/signatures.cpp
+++ b/src/signatures.cpp
@@ -207,10 +207,7 @@ array<uint64_t, 4> secret_key(const vector<uint8_t>& seed)
         array<uint64_t, 6> skBn = scalar::fromBytesBE<6>(span<uint8_t, 48>(okmHkdf.begin(), okmHkdf.end()));
         array<uint64_t, 6> quotient = {0, 0, 0, 0, 0, 0};
         array<uint64_t, 6> remainder = {0, 0, 0, 0, 0, 0};
-        // be conservative with scratch memory (https://github.com/relic-toolkit/relic/blob/ddd1984a76aa9c96a12ebdf5c6786b0ee6a26ef8/src/bn/relic_bn_div.c#L79)
-        // with gcc array<uint64_t, 4> q = fp::Q works fine but clang needs the two extra words
-        array<uint64_t, 6> q = {fp::Q[0], fp::Q[1], fp::Q[2], fp::Q[3], 0, 0};
-        bn_divn_low(quotient.data(), remainder.data(), skBn.data(), 6, q.data(), 4);
+        bn_divn_low(quotient.data(), remainder.data(), skBn.data(), 6, fp::Q.data(), 4);
         sk = {remainder[0], remainder[1], remainder[2], remainder[3]};
 
         if(!scalar::equal<4>(sk, {0, 0, 0, 0}))
@@ -342,8 +339,7 @@ g1 derive_child_g1_unhardened(
     array<uint64_t, 4> nonce = scalar::fromBytesBE<4>(span<uint8_t, 32>(digest.begin(), digest.end()));
     array<uint64_t, 4> quotient = {0, 0, 0, 0};
     array<uint64_t, 4> remainder = {0, 0, 0, 0};
-    array<uint64_t, 4> q = fp::Q;
-    bn_divn_low(quotient.data(), remainder.data(), nonce.data(), 4, q.data(), 4);
+    bn_divn_low(quotient.data(), remainder.data(), nonce.data(), 4, fp::Q.data(), 4);
     nonce = {remainder[0], remainder[1], remainder[2], remainder[3]};
 
     return pk.add(g1::one().mulScalar(nonce));
@@ -369,8 +365,7 @@ g2 derive_child_g2_unhardened(
     array<uint64_t, 4> nonce = scalar::fromBytesBE<4>(span<uint8_t, 32>(digest.begin(), digest.end()));
     array<uint64_t, 4> quotient = {0, 0, 0, 0};
     array<uint64_t, 4> remainder = {0, 0, 0, 0};
-    array<uint64_t, 4> q = fp::Q;
-    bn_divn_low(quotient.data(), remainder.data(), nonce.data(), 4, q.data(), 4);
+    bn_divn_low(quotient.data(), remainder.data(), nonce.data(), 4, fp::Q.data(), 4);
     nonce = {remainder[0], remainder[1], remainder[2], remainder[3]};
 
     return pk.add(g2::one().mulScalar(nonce));
@@ -389,8 +384,7 @@ array<uint64_t, 4> aggregate_secret_keys(const vector<array<uint64_t, 4>>& sks)
         ret = scalar::add<4, 4, 4>(ret, sks[i]);
         array<uint64_t, 4> quotient = {0, 0, 0, 0};
         array<uint64_t, 4> remainder = {0, 0, 0, 0};
-        array<uint64_t, 4> q = fp::Q;
-        bn_divn_low(quotient.data(), remainder.data(), ret.data(), 4, q.data(), 4);
+        bn_divn_low(quotient.data(), remainder.data(), ret.data(), 4, fp::Q.data(), 4);
         ret = {remainder[0], remainder[1], remainder[2], remainder[3]};
     }
 
@@ -413,8 +407,7 @@ array<uint64_t, 4> sk_from_bytes(
     {
         array<uint64_t, 4> quotient = {0, 0, 0, 0};
         array<uint64_t, 4> remainder = {0, 0, 0, 0};
-        array<uint64_t, 4> q = fp::Q;
-        bn_divn_low(quotient.data(), remainder.data(), sk.data(), 4, q.data(), 4);
+        bn_divn_low(quotient.data(), remainder.data(), sk.data(), 4, fp::Q.data(), 4);
         sk = {remainder[0], remainder[1], remainder[2], remainder[3]};
     }
     else


### PR DESCRIPTION
Fix the issue by:
Allocate temporary storage inside bn_divn_low() and remove unnecessary assignments before calling the function.

Note this is a relatively conservative fix. 
We might want to try some other approaches as well. (e.g. keep the function as is, double check and make sure we pass in buffers with enough spaces)
Be careful about merging.